### PR TITLE
use erlio fork of leveldb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
         {time_compat, {git, "git://github.com/lasp-lang/time_compat.git", "master"}},
         {lager, {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
         {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.0"}}},
-        {eleveldb, {git, "git://github.com/helium/eleveldb.git", {ref,"4e199ab1518060d348ae0f9719d2cbf9f098e00d"}}},
+        {eleveldb, {git, "git://github.com/erlio/eleveldb.git", "develop"}},
         %% adding edown at the above 'sext' to be able to build on Erlang >= 18
         {edown, {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}},
         {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.3"}}}


### PR DESCRIPTION
@ioolkos, @larshesel  this pulls in the erlio eleveldb fork, which uses the correct 2.0.0 leveldb tag. 
