### PR TITLE
Fix crash when rnd:seed returns undefined

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -512,7 +512,7 @@ new_segment_store(Opts, State) ->
     WriteBufferMin = proplists:get_value(write_buffer_size_min, Config, DefaultWriteBufferMin),
     WriteBufferMax = proplists:get_value(write_buffer_size_max, Config, DefaultWriteBufferMax),
     {Offset, _} = rnd:uniform_s(1 + WriteBufferMax - WriteBufferMin,
-                                   rnd:seed(time_compat:timestamp())),
+                                time_compat:timestamp()),
     WriteBufferSize = WriteBufferMin + Offset,
     Config2 = orddict:store(write_buffer_size, WriteBufferSize, Config),
     Config3 = orddict:erase(write_buffer_size_min, Config2),


### PR DESCRIPTION
No need to use rnd:seed/1 just use the output of time_compat:timestamp/0
directly.
