### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,6 @@
 {erl_opts, [warnings_as_errors, debug_info, {parse_transform, lager_transform},
             {platform_define, "20", otp20}]}.
 {deps, [
-        {time_compat, {git, "git://github.com/lasp-lang/time_compat.git", "master"}},
-        {erlang_rand_compat, {git, "git://github.com/tuncer/erlang-rand-compat.git", "master"}},
         {lager, {git, "git://github.com/basho/lager.git", {tag, "3.2.1"}}},
         {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.0"}}},
         {eleveldb, {git, "git://github.com/erlio/eleveldb.git", "develop"}},

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -494,7 +494,7 @@ new_segment_store(Opts, State) ->
     DataDir = case proplists:get_value(segment_path, Opts) of
                   undefined ->
                       Root = "/tmp/anti/level",
-                      <<P:128/integer>> = md5(term_to_binary({time_compat:timestamp(), make_ref()})),
+                      <<P:128/integer>> = md5(term_to_binary({erlang:timestamp(), make_ref()})),
                       filename:join(Root, integer_to_list(P));
                   SegmentPath ->
                       SegmentPath
@@ -511,9 +511,8 @@ new_segment_store(Opts, State) ->
     %% flushed to disk at once when under a heavy uniform load.
     WriteBufferMin = proplists:get_value(write_buffer_size_min, Config, DefaultWriteBufferMin),
     WriteBufferMax = proplists:get_value(write_buffer_size_max, Config, DefaultWriteBufferMax),
-    _ = rnd:seed(),
-    {Offset, _} = rnd:uniform_s(1 + WriteBufferMax - WriteBufferMin,
-                                rnd:seed(time_compat:timestamp())),
+    {Offset, _} = rand:uniform_s(1 + WriteBufferMax - WriteBufferMin,
+                                rand:seed(exsplus, erlang:timestamp())),
     WriteBufferSize = WriteBufferMin + Offset,
     Config2 = orddict:store(write_buffer_size, WriteBufferSize, Config),
     Config3 = orddict:erase(write_buffer_size_min, Config2),

--- a/src/hashtree_tree.erl
+++ b/src/hashtree_tree.erl
@@ -559,7 +559,7 @@ data_root(Opts) ->
     case proplists:get_value(data_dir, Opts) of
         undefined ->
             Base = "/tmp/hashtree_tree",
-            <<P:128/integer>> = crypto:hash(md5, term_to_binary(time_compat:timestamp())),
+            <<P:128/integer>> = crypto:hash(md5, term_to_binary(erlang:timestamp())),
             filename:join(Base, integer_to_list(P, 16));
         Root -> Root
     end.

--- a/src/plumtree.app.src
+++ b/src/plumtree.app.src
@@ -11,7 +11,6 @@
                   eleveldb,
                   riak_dt,
                   sext,
-                  rand_compat,
                   gen_server2
                  ]},
   {mod, { plumtree_app, []}},

--- a/src/plumtree_app.erl
+++ b/src/plumtree_app.erl
@@ -25,8 +25,6 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    _ = application:load(rand_compat),
-    {ok, rnd} = rand_compat:init(),
     _State = plumtree_peer_service_manager:init(),
     case plumtree_sup:start_link() of
         {ok, Pid} ->

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -560,8 +560,8 @@ random_other_node(OrdSet) ->
     case Size of
         0 -> undefined;
         _ ->
-            lists:nth(rnd:uniform(Size),
-                     ordsets:to_list(OrdSet))
+            lists:nth(rand:uniform(Size),
+                      ordsets:to_list(OrdSet))
     end.
 
 ack_outstanding(MessageId, Mod, Round, Root, From, State=#state{outstanding=All}) ->
@@ -726,19 +726,19 @@ init_peers(Members) ->
             %% with cycles. it will be adjusted as needed
             Tree = plumtree_util:build_tree(1, Members, [cycles]),
             InitEagers = orddict:fetch(node(), Tree),
-            InitLazys  = [lists:nth(rnd:uniform(N - 2), Members -- [node() | InitEagers])];
+            InitLazys  = [lists:nth(rand:uniform(N - 2), Members -- [node() | InitEagers])];
         N when N < 10 ->
             %% 5 to 9 members, start with gossip tree used by
             %% riak_core_gossip. it will be adjusted as needed
             Tree = plumtree_util:build_tree(2, Members, [cycles]),
             InitEagers = orddict:fetch(node(), Tree),
-            InitLazys  = [lists:nth(rnd:uniform(N - 3), Members -- [node() | InitEagers])];
+            InitLazys  = [lists:nth(rand:uniform(N - 3), Members -- [node() | InitEagers])];
         N ->
             %% 10 or more members, use a tree similar to riak_core_gossip
             %% but with higher fanout (larger initial eager set size)
             NEagers = round(math:log(N) + 1),
             Tree = plumtree_util:build_tree(NEagers, Members, [cycles]),
             InitEagers = orddict:fetch(node(), Tree),
-            InitLazys  = [lists:nth(rnd:uniform(N - (NEagers + 1)), Members -- [node() | InitEagers])]
+            InitLazys  = [lists:nth(rand:uniform(N - (NEagers + 1)), Members -- [node() | InitEagers])]
     end,
     {InitEagers, InitLazys}.

--- a/src/plumtree_metadata_leveldb_instance.erl
+++ b/src/plumtree_metadata_leveldb_instance.erl
@@ -120,7 +120,7 @@ iterator_close(Instance, Itr) when is_pid(Instance) or is_atom(Instance) ->
 %%--------------------------------------------------------------------
 init([InstanceId, Opts]) ->
     %% Initialize random seed
-    rnd:seed(time_compat:timestamp()),
+    rand:seed(exsplus, erlang:timestamp()),
 
     %% Get the data root directory
     DataDir1 = filename:join(app_helper:get_prop_or_env(plumtree_data_dir, Opts, plumtree),
@@ -288,7 +288,7 @@ init_state(DataRoot, Config) ->
     %% under heavy uniform load...
     WriteBufferMin = config_value(write_buffer_size_min, MergedConfig, 30 * 1024 * 1024),
     WriteBufferMax = config_value(write_buffer_size_max, MergedConfig, 60 * 1024 * 1024),
-    WriteBufferSize = WriteBufferMin + rnd:uniform(1 + WriteBufferMax - WriteBufferMin),
+    WriteBufferSize = WriteBufferMin + rand:uniform(1 + WriteBufferMax - WriteBufferMin),
 
     %% Update the write buffer size in the merged config and make sure create_if_missing is set
     %% to true

--- a/src/plumtree_peer_service.erl
+++ b/src/plumtree_peer_service.erl
@@ -106,7 +106,7 @@ random_peer(Leave) ->
         [] ->
             {error, singleton};
         _ ->
-            Idx = rnd:uniform(length(Peers)),
+            Idx = rand:uniform(length(Peers)),
             Peer = lists:nth(Idx, Peers),
             {ok, Peer}
     end.

--- a/src/plumtree_peer_service_gossip.erl
+++ b/src/plumtree_peer_service_gossip.erl
@@ -109,6 +109,6 @@ get_peers(Local) ->
 
 %% @doc return random peer from nodelist
 random_peer(Peers) ->
-    Idx = rnd:uniform(length(Peers)),
+    Idx = rand:uniform(length(Peers)),
     Peer = lists:nth(Idx, Peers),
     {ok, Peer}.

--- a/src/plumtree_peer_service_manager.erl
+++ b/src/plumtree_peer_service_manager.erl
@@ -78,7 +78,7 @@ add_self() ->
 %% @doc generate an actor for this node while alive
 gen_actor() ->
     Node = atom_to_list(node()),
-    {M, S, U} = time_compat:timestamp(),
+    {M, S, U} = erlang:timestamp(),
     TS = integer_to_list(M * 1000 * 1000 * 1000 * 1000 + S * 1000 * 1000 + U),
     Term = Node ++ TS,
     Actor = crypto:hash(sha, Term),


### PR DESCRIPTION
The `time_compat` and `rand_compat` applications were only needed when
we were compatible with OTP 17 which is no longer the case.