### PR TITLE
Dont broadcast to unreachable nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _tdeps
 logs
 erln8.config
 .local_dialyzer_plt
+*~

--- a/src/plumtree_broadcast.erl
+++ b/src/plumtree_broadcast.erl
@@ -464,8 +464,14 @@ send_lazy(#state{outstanding=Outstanding}) ->
     [send_lazy(Peer, Messages) || {Peer, Messages} <- orddict:to_list(Outstanding)].
 
 send_lazy(Peer, Messages) ->
-    [send_lazy(MessageId, Mod, Round, Root, Peer) ||
-        {MessageId, Mod, Round, Root} <- gb_sets:to_list(Messages)].
+    %% only send to members which are reachable
+    case lists:member(Peer, nodes()) of
+        true ->
+            [send_lazy(MessageId, Mod, Round, Root, Peer) ||
+                {MessageId, Mod, Round, Root} <- gb_sets:to_list(Messages)];
+        _ ->
+            ignore
+    end.
 
 send_lazy(MessageId, Mod, Round, Root, Peer) ->
     send({i_have, MessageId, Mod, Round, Root, node()}, Peer).


### PR DESCRIPTION
We shouldn't try to send out to the outstanding messages lazily if the receiving nodes are clearly not available (not in `nodes()`).

To test this out I had a three node cluster (three nodes are required to ensure that every node will have one node in it's lazy set), I killed two of them and on the remaining I would register 100K clients using `vmq_reg:register_subscriber`. That's the first spike on the below images. The X axis is time, the Y axis is the global scheduler load (using the VerneMQ scheduler_utilization metric). 

![plumtree_orig](https://user-images.githubusercontent.com/679187/35484387-85ba5afa-044f-11e8-833a-bf6c9792aaf7.png)

The first graph shows the periodic resend causing CPU usage when ever the outstanding messages is lazily broadcast. This pattern will continue forever as the receiving node will never acknowledge the messages. The 4 (and the beginning of one) small spikes translate to roughly 50% cpu usage as reported by `top`.

![plumtree_dont_send_to_unreachable](https://user-images.githubusercontent.com/679187/35484388-85d61470-044f-11e8-82f8-044022aabf33.png)

The second graph shows that there a no longer any spikes as we don't send out the outstanding messages to unreachable nodes.
