### PR TITLE
plumtree_peer_service: Fix to use connect_node/1

### DIFF
--- a/src/plumtree_peer_service.erl
+++ b/src/plumtree_peer_service.erl
@@ -48,7 +48,7 @@ join(_, Node, _Auto) ->
 
 attempt_join(Node) ->
     lager:info("Sent join request to: ~p~n", [Node]),
-    case net_kernel:connect(Node) of
+    case net_kernel:connect_node(Node) of
         false ->
             lager:info("Unable to connect to ~p~n", [Node]),
             {error, not_reachable};


### PR DESCRIPTION
`net_kernel:connect/1` was deprecated at OTP-21