### PR TITLE
Add support for OTP 22

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,12 +1,12 @@
 {erl_opts, [warnings_as_errors, debug_info, {parse_transform, lager_transform},
-            {platform_define, "20|21", nowarn_gen_fsm}]}.
+            {platform_define, "20|21|22", nowarn_gen_fsm}]}.
 {deps, [
         {lager, {git, "git://github.com/basho/lager.git", {tag, "3.2.1"}}},
         {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.0"}}},
-        {eleveldb, {git, "git://github.com/erlio/eleveldb.git", "develop"}},
+        {eleveldb, {git, "git://github.com/erlio/eleveldb.git", {branch, "develop"}}},
         %% adding edown at the above 'sext' to be able to build on Erlang >= 18
         {edown, {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}},
-        {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.3"}}},
+        {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.4.0"}}},
         {gen_server2, {git, "http://github.com/erlio/gen_server2.git", {branch, "master"}}}
        ]}.
 {overrides, [{override, sext, [{src_dirs, ["src"]}]}]}.


### PR DESCRIPTION
Make plumtree work on OTP 22.

Upgrading **sext** to a version newer than 1.4.0 breaks some of the membership tests, this will be a nice thing to do in the future. The current change allows VerneMQ to run fine on OTP 22.